### PR TITLE
Correct sha256 fingerprint for v3.0.1.tag.gz

### DIFF
--- a/grafana.rb
+++ b/grafana.rb
@@ -5,7 +5,7 @@ class Grafana < Formula
   homepage "https://grafana.org"
   url "https://github.com/grafana/grafana/archive/v3.0.1.tar.gz"
   version "3.0.1"
-  sha256 "bbd52c0b713a5220ae0e27f8471aa9877a7e6589"
+  sha256 "cf3bf4349614577abf1a4776af4134d929a525ce9619c57d982e77ee5f5592db"
 
   head "https://github.com/grafana/grafana.git"
 


### PR DESCRIPTION
It appears as if the sha256 fingerprint in the recipe is incorrect for the v3.0.1.tar.gz source archive - at a minimum it was too short.

This PR changes to fingerprint to match the current archive.