### PR TITLE
Fix launchd plist to use a valid WorkingDirectory

### DIFF
--- a/grafana.rb
+++ b/grafana.rb
@@ -71,7 +71,7 @@ class Grafana < Formula
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
-        <string>#{var}/share/grafana</string>
+        <string>#{var}/lib/grafana</string>
         <key>StandardErrorPath</key>
         <string>#{var}/log/grafana/grafana-stderr.log</string>
         <key>StandardOutPath</key>


### PR DESCRIPTION
`$(brew --prefix)/var/share` does not exist.

This fixes `brew services start grafana` so that it actually works.

Possibly `#{HOMEBREW_PREFIX}/share/grafana` (the same as `--homepath`) was intended—that also works, so I could change to that if desired, but using `var` and the same location as `default.paths.data` seemed sensible to me for process working directory.