### PR TITLE
update grafana-agent bottle checksums

### DIFF
--- a/grafana-agent.rb
+++ b/grafana-agent.rb
@@ -6,12 +6,12 @@ class GrafanaAgent < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "965486f37a35f04a044b90ac1f08da9bcb55b4bbf331b58b39d742958e93ad1d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4a929231267626974a92ed4dad3bd832a8e333ca5c552c509644724b534fdd47"
-    sha256 cellar: :any_skip_relocation, monterey:       "6dfc863d09d4f7eeb3235d2f5f83e0d6ae32815d6f9171a1499be3abc0b5158d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "fc5013df72b19400084621faba202363952aa4e12148461959735676762f1d9d"
-    sha256 cellar: :any_skip_relocation, catalina:       "392fb5b5a8c60118e9aacc205d7f77625cead5e939f8daf474c94af0ffe09957"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "caef53f6302308ab644285e538954b5dbc6e7e5b073c0217ff55b1266d5ef834"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "bab099008ea51ea316dd70c4d9673ac7eab6149dd3b9c62ab198b8ca7df15880"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "39da596276b4d240e46c36ac0664942270c82dcfdc64ef590c4b2ceefcf46404"
+    sha256 cellar: :any_skip_relocation, monterey:       "c97b0730792eabdf17b2812e5577e354f52165b7abf3790f82fa4afc7a084ec7"
+    sha256 cellar: :any_skip_relocation, big_sur:        "2aaf8f39bf8239f5a633fe4520cbcacfa0dfd35f375904de27610ceff925d51b"
+    sha256 cellar: :any_skip_relocation, catalina:       "cdb94c433986171f0eddf729c2f1ca94a888d9bab4241cd7c740f424cd310f7a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cda0a043d29204e87815f0003cbc8f6082b0834aacb59e4fd84fd836bccb9fdf"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Fixes https://github.com/grafana/homebrew-grafana/issues/24.

Homebrew core has an automated process for updating bottles after merging a PR generated with `brew bump-formula-pr`.  I'm opening the following issue https://github.com/grafana/homebrew-grafana/issues/25 to track this.