### PR TITLE
Deprecate mimirtool formula in favour of formula in homebrew-core.

### DIFF
--- a/mimirtool.rb
+++ b/mimirtool.rb
@@ -4,6 +4,8 @@ class Mimirtool < Formula
   homepage "https://grafana.com"
   version "2.1.0"
 
+  deprecate! date: "2022-12-15", because: "is not maintained; use mimirtool formula from homebrew-core instead (brew uninstall grafana/grafana/mimirtool && brew install mimirtool)"
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/grafana/mimir/releases/download/mimir-2.1.0/mimirtool-darwin-arm64"


### PR DESCRIPTION
We've set up a Homebrew formula for `mimirtool` in homebrew-core that is automatically updated whenever we release a new version of Mimir: https://github.com/Homebrew/homebrew-core/blob/master/Formula/mimirtool.rb

We don't plan to maintain the formula in this tap, so this PR marks it as deprecated and nudges anyone using it to move to the formula in homebrew-core.