### PR TITLE
grafana-agent-flow: create Grafana Agent Flow formula

### DIFF
--- a/grafana-agent-flow.rb
+++ b/grafana-agent-flow.rb
@@ -1,0 +1,81 @@
+class GrafanaAgentFlow < Formula
+  desc "Vendor-neutral programmable observability pipelines."
+  homepage "https://grafana.com/docs/agent/latest/flow"
+  url "https://github.com/grafana/agent/archive/refs/tags/v0.32.1.tar.gz"
+  sha256 "2b91c3a3e522d79a9375bba806684cb6a9a14eab02613c81a01b8440d5bc7a12"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+  depends_on "node" => :build
+  depends_on "yarn" => :build
+
+  on_linux do
+    depends_on "systemd" => :build
+  end
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/grafana/agent/pkg/build.Branch=HEAD
+      -X github.com/grafana/agent/pkg/build.Version=v#{version}
+      -X github.com/grafana/agent/pkg/build.BuildUser=#{tap.user}
+      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.iso8601}
+    ]
+    args = std_go_args(ldflags: ldflags) + %w[-tags=builtinassets,noebpf]
+
+    # Build the UI, which is baked into the final binary when the builtinassets
+    # tag is set.
+    cd "web/ui" do
+      system "yarn"
+      system "yarn", "run", "build"
+    end
+
+    system "go", "build", *args, "-o", bin/"grafana-agent-flow", "./cmd/grafana-agent"
+  end
+
+  def post_install
+    (etc/"grafana-agent-flow").mkpath
+  end
+
+  def caveats
+    <<~EOS
+      The agent uses a configuration file that you must customize before running:
+        #{etc}/grafana-agent-flow/config.river
+    EOS
+  end
+
+  service do
+    run [
+      opt_bin/"grafana-agent-flow", "run", etc/"grafana-agent/config.river",
+      "--server.http.listen-addr=127.0.0.1:12345",
+      "--storage.path=#{etc}/grafana-agent/data",
+    ]
+    environment_variables AGENT_MODE: "flow"
+    keep_alive true
+    log_path var/"log/grafana-agent.log"
+    error_log_path var/"log/grafana-agent.err.log"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/grafana-agent-flow --version")
+
+    port = free_port
+
+    (testpath/"grafana-agent.river").write <<~EOS
+      logging {
+        level = "info"
+      }
+    EOS
+
+    fork do
+      ENV["AGENT_MODE"] = "flow"
+      exec bin/"grafana-agent-flow", "run", "#{testpath}/grafana-agent.river",
+        "--server.http.listen-addr=127.0.0.1:#{port}",
+        "--storage.path=#{testpath}/data"
+    end
+    sleep 10
+
+    output = shell_output("curl -s 127.0.0.1:#{port}/metrics")
+    assert_match "agent_build_info", output
+  end
+end


### PR DESCRIPTION
Create a temporary formula for Grafana Agent Flow which can be installed alongside the normal Grafana Agent installation.

This installs the normal Grafana Agent binary as `grafana-agent-flow`. The v0.33 release will include a [Flow-specific command](https://github.com/grafana/agent/tree/main/cmd/grafana-agent-flow), which will then be installed instead. 

Note that this forces the use of 127.0.0.1:12345 as the HTTP listen address when using `brew services`. To edit, users will need to run `brew edit grafana/grafana/grafana-agent-flow` before installing or before reinstalling to make changes.