### PR TITLE
Fix grafana-agent-flow checksum

### DIFF
--- a/grafana-agent-flow.rb
+++ b/grafana-agent-flow.rb
@@ -2,7 +2,7 @@ class GrafanaAgentFlow < Formula
   desc "Vendor-neutral programmable observability pipelines."
   homepage "https://grafana.com/docs/agent/latest/flow"
   url "https://github.com/grafana/agent/archive/refs/tags/v0.35.4.tar.gz"
-  sha256 "4847360e87bb2c9088f4b629ccfbaa84e424f23fa3442a55f73fc598a779e503"
+  sha256 "c0949268d6b4a08009b226f0b6b0c1daf1ef6fb433811e6094e25796baaec9cf"
   license "Apache-2.0"
 
   depends_on "go" => :build


### PR DESCRIPTION
**OS:** MacOS 13.5.1
**Homebrew version:** Homebrew 4.1.6

Tried installing grafana-agent-flow via Homebrew, ran into an issue with the checksum:

```
==> Verifying checksum for '245d475b29f997ed5237694490bd06fa1403b2d6d653e806adcb2b7206dff8b4--agent-0.35.4.tar.gz'
Error: grafana-agent-flow: SHA256 mismatch
Expected: 4847360e87bb2c9088f4b629ccfbaa84e424f23fa3442a55f73fc598a779e503
  Actual: c0949268d6b4a08009b226f0b6b0c1daf1ef6fb433811e6094e25796baaec9cf
    File: /Users/leannashippy/Library/Caches/Homebrew/downloads/245d475b29f997ed5237694490bd06fa1403b2d6d653e806adcb2b7206dff8b4--agent-0.35.4.tar.gz
To retry an incomplete download, remove the file above.
~/Downloads rm /Users/leannashippy/Library/Caches/Homebrew/downloads/245d475b29f997ed5237694490bd06fa1403b2d6d653e806adcb2b7206dff8b4--agent-0.35.4.tar.gz
~/Downloads brew cleanup
 ~/Downloads brew upgrade
```

After attempting to install by removing the cached download file as prescribed by Homebrew, running `brew cleanup`, and `brew upgrade`, the issue persisted.

I downloaded the `agent-0.35.4.tar.gz` tarball referenced in the `grafana-agent-flow.rb` file to check the checksum and the checksum of that file is different than the one specified  in the `grafana-agent-flow.rb` file.

```
~/Downloads shasum -a 256 /Users/leannashippy/Downloads/agent-0.35.4.tar.gz
c0949268d6b4a08009b226f0b6b0c1daf1ef6fb433811e6094e25796baaec9cf  /Users/leannashippy/Downloads/agent-0.35.4.tar.gz
```

This PR fixes the checksum in the `grafana-agent-flow.rb` file to match the checksum of the `agent-0.35.4.tar.gz` file