### PR TITLE
grafana-agent-flow: Fix web/ui path

### DIFF
--- a/grafana-agent-flow.rb
+++ b/grafana-agent-flow.rb
@@ -25,7 +25,7 @@ class GrafanaAgentFlow < Formula
 
     # Build the UI, which is baked into the final binary when the builtinassets
     # tag is set.
-    cd "web/ui" do
+    cd "internal/web/ui" do
       system "yarn"
       system "yarn", "run", "build"
     end


### PR DESCRIPTION
The web/ui path has changed in 0.41 to a new directory. 

Fixes grafana/agent#6958