### PR TITLE
Force go@1.22 to avoid issue with pyroscope

### DIFF
--- a/alloy.rb
+++ b/alloy.rb
@@ -5,7 +5,7 @@ class Alloy < Formula
     sha256 "422aa6ab7b9e606ebec2edcde79d6f26b6e648da85955fd1d5d08d6e33e7c537"
     license "Apache-2.0"
   
-    depends_on "go" => :build
+    depends_on "go@1.22" => :build
     depends_on "node" => :build
     depends_on "yarn" => :build
   


### PR DESCRIPTION
Its fixed upstream in pyroscope but this is a lot lower in terms of risk than updating in a patch release. We will fix in 1.4