### PR TITLE
Enable Alloy to run with env vars and extra args

### DIFF
--- a/alloy.rb
+++ b/alloy.rb
@@ -32,6 +32,7 @@ class Alloy < Formula
 
       system "go", "build", *args, "-o", bin/"alloy", "."
 
+      # Create a config.alloy file with default Alloy configuration
       (buildpath/"config.alloy").write <<~EOS
         logging {
           level  = "info"
@@ -40,22 +41,54 @@ class Alloy < Formula
       EOS
 
       (etc/"alloy").install "config.alloy"
+
+      # Create an empty config.env file for environment variables
+      (buildpath/"config.env").write ""
+      (etc/"alloy").install "config.env"
+
+      # Create an empty extra-args.txt file for extra command line arguments
+      (buildpath/"extra-args.txt").write ""
+      (etc/"alloy").install "extra-args.txt"
+
+      # Create a wrapper script to run Alloy using the config in config.alloy,
+      # env vars in config.env, and extra args in extra-args.txt
+      (buildpath/"alloy-wrapper").write <<~SH
+      #!/usr/bin/env sh
+      source "#{etc}/alloy/config.env"
+
+      COMMAND="#{opt_bin}/alloy run #{etc}/alloy/config.alloy \
+      --server.http.listen-addr=0.0.0.0:12345 \
+      --storage.path=#{var}/lib/alloy/data"
+
+      EXTRA_ARGS=$(cat "#{etc}/alloy/extra-args.txt")
+
+      if [ -z "$EXTRA_ARGS" ]; then
+        exec $COMMAND
+      else
+        exec $COMMAND $EXTRA_ARGS
+      fi
+      SH
+
+      bin.install "alloy-wrapper"
+      (bin/"alloy-wrapper").chmod 0755
+
       mkdir_p (var/"lib/alloy/data")
     end
 
     def caveats
       <<~EOS
-        Alloy uses a configuration file that you can customize before running:
-          #{etc}/alloy/config.alloy
+        Alloy uses a set of files that you can customize before running:
+          Configuration:
+            #{etc}/alloy/config.alloy
+          Environment variables:
+            #{etc}/alloy/config.env
+          Extra command line arguments:
+            #{etc}/alloy/extra-args.txt
       EOS
     end
 
     service do
-      run [
-        opt_bin/"alloy", "run", etc/"alloy/config.alloy",
-        "--server.http.listen-addr=127.0.0.1:12345",
-        "--storage.path=#{var}/lib/alloy/data",
-      ]
+      run ["#{opt_bin}/alloy-wrapper"]
       keep_alive true
       log_path var/"log/alloy.log"
       error_log_path var/"log/alloy.err.log"


### PR DESCRIPTION
To enable Alloy to run as a background service with user-defined environment variables and extra command line arguments, this PR updates the Alloy formula to:
- Create an empty file `$(brew --prefix)/etc/alloy/config.env` for env vars
- Create an empty file `$(brew --prefix)/etc/alloy/extra-args.txt` for extra args
- Create an wrapper script `$(brew --prefix)/Cellar/alloy/<version>/bin/alloy-wrapper` which runs Alloy with the env vars and extra args, if any
- Update the service run command to execute the wrapper script

These changes are motivated by the necessity to:
- Pass the extra argument `--stability.level=public-preview` to run Alloy with remote config support
- Set certain environment variables, i.e. `GCLOUD_RW_API_KEY`, `GCLOUD_FM_COLLECTOR_ID` and `GCLOUD_FM_LOG_PATH`, for the Alloy self-monitoring pipelines in Grafana Cloud Fleet Management to work