### PR TITLE
Update alloy.rb to fix broken build

### DIFF
--- a/alloy.rb
+++ b/alloy.rb
@@ -7,7 +7,7 @@ class Alloy < Formula
     sha256 "7b1647ad5ebdd455ffacef045e4a6d6a07b4a703040a5127ff00cf25ea26ba58"
     license "Apache-2.0"
   
-    depends_on "go@1.23" => :build
+    depends_on "go@1.24" => :build
     depends_on "node@20" => :build
     depends_on "yarn" => :build
 


### PR DESCRIPTION
Latest version requires a new version of go or else install fails:

```
brew install grafana/grafana/alloy
==> Fetching grafana/grafana/alloy
==> Downloading https://github.com/grafana/alloy/archive/refs/tags/v1.8.0.tar.gz
Already downloaded: /Users/dalehamel/Library/Caches/Homebrew/downloads/e088e932555070e002aa747874fc40bc22530ca1953fc686e73e1b8a2a50813d--alloy-1.8.0.tar.gz
==> Installing alloy from grafana/grafana
==> yarn
==> yarn run build
==> go build -ldflags=-s -w -X github.com/grafana/alloy/internal/build.Branch=HEAD -X github.com/grafana/alloy/internal/build.Version=v1.8.0 -X github.com/grafana/alloy/internal/build.BuildUser=grafana -X github.com/grafana/
Last 15 lines from /Users/dalehamel/Library/Logs/Homebrew/alloy/03.go:
2025-04-09 15:15:51 +0000

go
build
-trimpath
-o=/opt/homebrew/Cellar/alloy/1.8.0/bin/alloy
-ldflags=-s -w -X github.com/grafana/alloy/internal/build.Branch=HEAD -X github.com/grafana/alloy/internal/build.Version=v1.8.0 -X github.com/grafana/alloy/internal/build.BuildUser=grafana -X github.com/grafana/alloy/internal/build.BuildDate=2025-04-09T13:08:04Z
-tags=builtinassets,noebpf
-o
/opt/homebrew/Cellar/alloy/1.8.0/bin/alloy
.

go: go.mod requires go >= 1.24.1 (running go 1.23.8; GOTOOLCHAIN=local)

If reporting this issue please do so at (not Homebrew/* repositories):
  https://github.com/grafana/homebrew-grafana/issues
```

After this change (verified with `brew edit grafana/grafana/alloy`):

```
brew install grafana/grafana/alloy
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Fetching grafana/grafana/alloy
==> Downloading https://github.com/grafana/alloy/archive/refs/tags/v1.8.0.tar.gz
Already downloaded: /Users/dalehamel/Library/Caches/Homebrew/downloads/e088e932555070e002aa747874fc40bc22530ca1953fc686e73e1b8a2a50813d--alloy-1.8.0.tar.gz
==> Installing alloy from grafana/grafana
==> yarn
==> yarn run build
==> go build -ldflags=-s -w -X github.com/grafana/alloy/internal/build.Branch=HEAD -X github.com/grafana/alloy/internal/build.Version=v1.8.0 -X github.com/grafana/alloy/internal/build.BuildUser=grafana -X github.com/grafana/
==> Caveats
Alloy uses a set of files that you can customize before running:
  Configuration:
    /opt/homebrew/etc/alloy/config.alloy
  Environment variables:
    /opt/homebrew/etc/alloy/config.env
  Extra command line arguments:
    /opt/homebrew/etc/alloy/extra-args.txt

To start grafana/grafana/alloy now and restart at login:
  brew services start grafana/grafana/alloy
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/alloy/bin/alloy-wrapper
==> Summary
🍺  /opt/homebrew/Cellar/alloy/1.8.0: 10 files, 283.0MB, built in 2 minutes 51 seconds
==> Running `brew cleanup alloy`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```