### PR TITLE
Fix "No available formula" Error From Node Dependency

### DIFF
--- a/alloy.rb
+++ b/alloy.rb
@@ -8,7 +8,7 @@ class Alloy < Formula
     license "Apache-2.0"
   
     depends_on "go@1.25" => :build
-    depends_on "node@24.4" => :build
+    depends_on "node@24" => :build
 
     on_linux do
       depends_on "systemd" => :build


### PR DESCRIPTION
When running `brew upgrade grafana/grafana/alloy` we get the following error

```
Error: No available formula with the name "node@24.4" (dependency of grafana/grafana/alloy). Did you mean node@24?
```

Running a formula search I also see

```
➜  alloy git:(basic-otel-engine-and-extension-poc-hackathon-15-alloy-otel-opamp) ✗ brew search node@24.4
==> Formulae
node@24
```

This PR fixes the reference so that we're pulling `node@24` instead