### PR TITLE
sigil cli 0.7.0

### DIFF
--- a/sigil.rb
+++ b/sigil.rb
@@ -1,19 +1,25 @@
 class Sigil < Formula
   desc "Hook binary for the Grafana AI Observability (Sigil) agent plugins"
   homepage "https://github.com/grafana/sigil-sdk/tree/main/plugins/sigil"
-  url "https://github.com/grafana/sigil-sdk/archive/refs/tags/plugins/sigil/v0.5.0.tar.gz"
-  version "0.5.0"
-  sha256 "22d8c6c728a1f353df9f002303bad80dc1e9669a563aef178b28096a768fe745"
+  url "https://github.com/grafana/sigil-sdk/archive/refs/tags/plugins/sigil/v0.7.0.tar.gz"
+  version "0.7.0"
+  sha256 "96627d669f9db7bb070c4a86d2038e8461d564b99c93cacedf33b23f84f0a48a"
   license "Apache-2.0"
   head "https://github.com/grafana/sigil-sdk.git", branch: "main"
 
   depends_on "go" => :build
 
   def install
+    version_string = if build.head?
+      "dev-#{Utils.git_short_head}"
+    else
+      "v#{version}"
+    end
+
     cd "plugins/sigil" do
       ldflags = %W[
         -s -w
-        -X main.version=v#{version}
+        -X main.version=#{version_string}
       ]
 
       system "go", "build",
@@ -24,6 +30,7 @@ class Sigil < Formula
   end
 
   test do
-    assert_match "v#{version}", shell_output("#{bin}/sigil --version")
+    expected = build.head? ? "dev-" : "v#{version}"
+    assert_match expected, shell_output("#{bin}/sigil --version")
   end
 end


### PR DESCRIPTION
Also tag HEAD builds as `dev-<short sha>`. `main.version` is propagated to telemetry as `agent_version`, so HEAD installs were reporting themselves as `v0.5.0`.