### PR TITLE
Rename sigil formula to agento11y

### DIFF
--- a/agento11y.rb
+++ b/agento11y.rb
@@ -1,10 +1,11 @@
-class Sigil < Formula
+class Agento11y < Formula
   desc "CLI for the Grafana AI Observability (Sigil) agent plugins"
   homepage "https://github.com/grafana/sigil-sdk/tree/main/plugins/sigil"
   url "https://github.com/grafana/sigil-sdk/archive/refs/tags/plugins/sigil/v0.18.0.tar.gz"
   version "0.18.0"
   sha256 "5a0032312312f23955ddbace70623c9c148b509198cbf3aed28d9ff8acac048e"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/grafana/sigil-sdk.git", branch: "main"
 
   depends_on "go" => :build
@@ -24,13 +25,16 @@ class Sigil < Formula
 
       system "go", "build",
         "-buildvcs=false",
-        *std_go_args(ldflags: ldflags, output: bin/"sigil"),
+        *std_go_args(ldflags: ldflags, output: bin/"agento11y"),
         "./cmd/sigil"
     end
+
+    bin.install_symlink "agento11y" => "sigil"
   end
 
   test do
     expected = build.head? ? "dev-" : "v#{version}"
+    assert_match expected, shell_output("#{bin}/agento11y --version")
     assert_match expected, shell_output("#{bin}/sigil --version")
   end
 end

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,3 +1,4 @@
 {
-  "grafana-cloud-agent": "grafana-agent"
+  "grafana-cloud-agent": "grafana-agent",
+  "sigil": "agento11y"
 }


### PR DESCRIPTION
The formula now installs an `agento11y` binary with a `sigil` compatibility symlink, and the rename entry in `formula_renames.json` migrates existing installs on upgrade.

Part of https://github.com/grafana/sigil/issues/1282